### PR TITLE
Hyperlink DOIs against secure, preferred resolver

### DIFF
--- a/utils.php
+++ b/utils.php
@@ -175,7 +175,7 @@ function gcmd_curl($gcmd) {
 }
 
 function doi_curl($doi) {
-	$url = 'http://dx.doi.org/' . $doi;
+	$url = 'https://doi.org/' . $doi;
 
 	$curl = curl_init();
 	curl_setopt($curl, CURLOPT_URL, $url);


### PR DESCRIPTION
Hello :-)

The DOI foundation recommends [this new, secure resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8).

Cheers!